### PR TITLE
fix: classcastexception with document and bsondocument when try to get resumetoken

### DIFF
--- a/src/main/java/com/movinfo/messenger/MongoChangeStreamWatcher.java
+++ b/src/main/java/com/movinfo/messenger/MongoChangeStreamWatcher.java
@@ -19,7 +19,7 @@ public class MongoChangeStreamWatcher {
 
     public void watchForUpdates() {
         Document tokenDoc = tokenCollection.find(new Document("stream", "movieStream")).first();
-        BsonDocument lastResumeToken = tokenDoc != null ? tokenDoc.get("resumeToken", BsonDocument.class) : null;
+        BsonDocument lastResumeToken = tokenDoc != null ? tokenDoc.get("resumeToken", Document.class).toBsonDocument() : null;
 
         MongoCursor<ChangeStreamDocument<Document>> cursor;
         if (lastResumeToken != null) {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Try get resumetoken to Document.class and then using toBsonDocument to change type

### PR Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore
- [x] Bug fix
- [ ] New feature
