### PR TITLE
fix: execute mongo stream after jda init finished

### DIFF
--- a/src/main/java/com/movinfo/messenger/App.java
+++ b/src/main/java/com/movinfo/messenger/App.java
@@ -15,8 +15,5 @@ public class App
         // init
         MongoUtils.init();
         JDAUtils.init();
-
-        // execute
-        MongoUtils.watchMovieInfo();
     }
 }

--- a/src/main/java/com/movinfo/messenger/handler/InitialHandler.java
+++ b/src/main/java/com/movinfo/messenger/handler/InitialHandler.java
@@ -2,6 +2,7 @@ package com.movinfo.messenger.handler;
 
 import com.movinfo.messenger.command.MessageSender;
 import com.movinfo.messenger.util.JDAUtils;
+import com.movinfo.messenger.util.MongoUtils;
 
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.session.ReadyEvent;
@@ -15,6 +16,8 @@ public class InitialHandler extends ListenerAdapter{
     }
 
     private void sendNotificationButtonIfNotSent(ReadyEvent event){
+        MongoUtils.watchMovieInfo();
+        
         MessageChannel channel = event.getJDA().getTextChannelById(JDAUtils.getNotiSetChannelId());
         
         if (channel != null) {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Execute mongo stream after jda init finished.

### PR Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore
- [x] Bug fix
- [ ] New feature
