### PR TITLE
fix: using deferEdit method to send no reply for screentype select event

### DIFF
--- a/src/main/java/com/movinfo/messenger/handler/SelectMenuHandler.java
+++ b/src/main/java/com/movinfo/messenger/handler/SelectMenuHandler.java
@@ -67,7 +67,7 @@ public class SelectMenuHandler extends ListenerAdapter{
             }
         }
         
-        event.deferReply(true).queue();
+        event.deferEdit().queue();
     }
 
     @Override


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Using deferEdit method to send no reply for screentype select event.

### PR Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore
- [x] Bug fix
- [ ] New feature
