### PR TITLE
fix: screen type select option is not selected as default even if the…

### DIFF
--- a/src/main/java/com/movinfo/messenger/handler/SelectMenuHandler.java
+++ b/src/main/java/com/movinfo/messenger/handler/SelectMenuHandler.java
@@ -26,11 +26,11 @@ public class SelectMenuHandler extends ListenerAdapter{
         List<SelectOption> selectOptions = new LinkedList<>();
         for (String type : Screen.SCREEN_TYPE_LIST){
             String roleName = selectedMovieName+"_"+type;
-            SelectOption option = SelectOption.of(type, roleName);
+            SelectOption option;
             if (RoleManager.hasRole(JDAUtils.getGuild(), selectedMovieName+"_"+type, event.getUser())){
-                option.withDefault(true);
+                option = SelectOption.of(type, roleName).withDefault(true);
             } else {
-                option.withDefault(false);
+                option = SelectOption.of(type, roleName).withDefault(false);
             }
             selectOptions.add(option);
         }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Screen type select option is not selected as default even if the screen was selected before.

### PR Type
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore
- [x] Bug fix
- [ ] New feature
